### PR TITLE
create pseudo renderer, parser, extractor and update the content with a…

### DIFF
--- a/frontend/components/latex-renderer.tsx
+++ b/frontend/components/latex-renderer.tsx
@@ -10,6 +10,7 @@ import type {
   LatexContent,
   ListItem,
 } from "@/lib/latex-parser";
+import { PseudocodeRenderer } from "./pseudocode-renderer";
 
 interface LatexRendererProps {
   content: LatexContent[];
@@ -156,6 +157,12 @@ export function LatexRenderer({ content }: LatexRendererProps) {
             />
           </div>
         );
+      case "pseudocode":
+        return (
+          <div key={index}>
+            <PseudocodeRenderer code={item?.content ?? ""} />
+          </div>
+        );
 
       case "list":
         const ListTag = item.ordered ? "ol" : "ul";
@@ -179,7 +186,7 @@ export function LatexRenderer({ content }: LatexRendererProps) {
       ref={contentRef}
       className="tutorial-content prose prose-slate max-w-none dark:prose-invert"
     >
-      <style jsx>{`
+      <style>{`
         /* Ensure proper nesting styles for lists */
         .tutorial-content ol {
           counter-reset: item;

--- a/frontend/components/pseudocode-renderer.tsx
+++ b/frontend/components/pseudocode-renderer.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+
+interface PseudocodeRendererProps {
+  code: string;
+  title?: string;
+  className?: string;
+}
+
+export function PseudocodeRenderer({
+  code: initialCode,
+  title = "Pseudocode",
+  className = "",
+}: PseudocodeRendererProps) {
+  const [code] = useState(initialCode);
+  const codeTextareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Auto-resize textarea based on content
+  useEffect(() => {
+    if (codeTextareaRef.current) {
+      codeTextareaRef.current.style.height = "auto";
+      codeTextareaRef.current.style.height = `${codeTextareaRef.current.scrollHeight}px`;
+    }
+  }, [code]);
+
+  return (
+    <div className={`pseudocode-renderer-container ${className}`}>
+      {/* Pseudocode Display */}
+      <Card className="border rounded-md overflow-hidden">
+        <div className="group flex items-center justify-between bg-muted p-1 border-b">
+          <Badge variant="outline">{title}</Badge>
+        </div>
+
+        <div className="relative">
+          <textarea
+            ref={codeTextareaRef}
+            value={code}
+            readOnly
+            spellCheck={false}
+            className="w-full font-mono text-sm p-4 resize-none bg-background cursor-default focus:outline-none"
+            style={{
+              lineHeight: "1.5",
+              tabSize: 2,
+            }}
+          />
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/tutorials/comparision.tex
+++ b/frontend/tutorials/comparision.tex
@@ -20,7 +20,7 @@ The Hyperon Pattern Miner differs from classical pattern mining methods in sever
 
 Apriori \cite{agrawal1994fast} is in many ways the grand-daddy of frequent pattern mining algorithms.  It finds frequent itemsets in transactional data by level-wise candidate generation and pruning.
 
-\begin{verbatim}
+\begin{algpseudocode}
 Algorithm Apriori(D, min_support):
     L1 = { frequent 1-itemsets in D }
     k = 2
@@ -33,7 +33,7 @@ Algorithm Apriori(D, min_support):
         Lk = { c in Ck | count[c] >= min_support }
         k += 1
     return Union of all Lk
-\end{verbatim}
+\end{algpseudocode}
 
 In Apriori, the algorithm first scans the entire dataset once to count each individual item's frequency and collects those that meet the minimum support threshold.  It then enters a loop where, at iteration $k$, it generates candidate $k$-itemsets by joining pairs of frequent $(k-1)$-itemsets that share $(k-2)$ items (the \texttt{apriori\_gen} step).  For each transaction, it tests which candidates are subsets of that transaction and increments their counts.  After scanning all transactions, it discards candidates whose counts fall below \texttt{min\_support}.  This process repeats, increasing $k$, until no new candidates survive, and the union of all frequent itemsets is returned.
 
@@ -41,7 +41,7 @@ In Apriori, the algorithm first scans the entire dataset once to count each indi
 
 FP-growth \cite{han2000mining} builds a compact prefix tree and mines it recursively without explicit candidate generation.
 
-\begin{verbatim}
+\begin{algpseudocode}
 Function FP_Growth(D, min_support):
     tree = build_fp_tree(D, min_support)
     return mine_tree(tree, [])
@@ -53,7 +53,7 @@ Procedure mine_tree(tree, prefix):
         conditional_tree = build_fp_tree(conditional_db, min_support)
         if conditional_tree not empty:
             mine_tree(conditional_tree, new_pattern)
-\end{verbatim}
+\end{algpseudocode}
 
 FP-growth begins by constructing an FP-tree: it reads each transaction, orders its frequent items by descending global frequency, and inserts that ordered list as a branch in the tree, sharing common prefixes.  The tree's header table links all occurrences of each item.  To mine the tree, the algorithm processes each item in the header: it appends the item to the current prefix to form a new frequent pattern, builds a conditional pattern base \texttt{(the set of prefix paths leading to that item)}, constructs a conditional FP-tree from that base, and recursively mines the conditional tree.  This avoids the costly candidate generation of Apriori by reusing the tree structure to count pattern occurrences.
 
@@ -61,14 +61,14 @@ FP-growth begins by constructing an FP-tree: it reads each transaction, orders i
 
 PrefixSpan \cite{pei2001prefixspan} extends sequence mining by recursively projecting databases on discovered prefixes.
 
-\begin{verbatim}
+\begin{algpseudocode}
 Procedure PrefixSpan(S, prefix, min_support):
     for each item i with support >= min_support in S:
         new_pattern = prefix U {i}
         output new_pattern
         projected_db = project_database(S, i)
         PrefixSpan(projected_db, new_pattern, min_support)
-\end{verbatim}
+\end{algpseudocode}
 
 PrefixSpan treats each sequence in the database $s$ as an ordered list of items.  At each call, it finds all items that appear at least \texttt{min\_support} times after the current \texttt{prefix}.  For each such item $i$, it extends the prefix by $i$, outputs the new sequential pattern, then constructs the \emph{projected database} of suffix subsequences that follow each occurrence of $i$ in the original sequences.  The algorithm then recurses on this smaller database.  This pattern-growth approach efficiently enumerates all frequent sequences without generating candidates explicitly.
 
@@ -78,7 +78,7 @@ PrefixSpan treats each sequence in the database $s$ as an ordered list of items.
 
 gSpan \cite{yan2002gspan} discovers frequent subgraphs by depth-first search and canonical DFS codes.
 
-\begin{verbatim}
+\begin{algpseudocode}
 Algorithm gSpan(GraphDB, min_support):
     for each frequent single-edge pattern p:
         DFS_Code = min_dfs_code(p)
@@ -89,7 +89,7 @@ Procedure subgraph_mining(p, GraphDB, DFS_Code, min_support):
             p_new = p extended by e
             DFS_Code_new = update_dfs_code(DFS_Code, e)
             subgraph_mining(p_new, GraphDB, DFS_Code_new, min_support)
-\end{verbatim}
+\{algpseudocode}
 
 gSpan first enumerates all edges that occur in at least \texttt{min\_support} graphs and computes their minimum DFS code--a canonical string representation that uniquely identifies a graph.  In the recursive \texttt{subgraph\_mining} procedure, it attempts to extend the current pattern $p$ by adding one edge \texttt{(and possibly a new node)}, computes the new DFS code for the extended graph, and checks its support across the graph database.  Only extensions meeting the support threshold are pursued further.  By using DFS codes to avoid duplicate subgraph generation, gSpan efficiently explores the lattice of frequent subgraphs.
 
@@ -99,7 +99,7 @@ gSpan first enumerates all edges that occur in at least \texttt{min\_support} gr
 
 WARMR \cite{dehaspe1999frequent} mines frequent relational patterns \texttt{(logical clauses)} by iteratively refining hypotheses.
 
-\begin{verbatim}
+\begin{algpseudocode}
 Procedure WARMR(min_support):
     C1 = generate_initial_clauses(language_bias)
     k = 1
@@ -108,7 +108,7 @@ Procedure WARMR(min_support):
         C(k+1) = refine_clauses(Lk)
         k += 1
     return Union of all Lk
-\end{verbatim}
+\end{algpseudocode}
 
 WARMR operates in the inductive logic programming setting.  It begins by generating a set $C_1$ of all possible single-literal clauses permitted by a user-supplied language bias.  At each iteration $k$, it selects those clauses in $C_k$ whose support across the logical database meets \texttt{min\_support}, calls this $L_k$, then \emph{refines} each clause in $L_k$ by adding one additional literal in all allowed ways to form the next candidate set $C_{k+1}$.  This loop continues until no new clauses survive, and the union of all frequent clauses $L_1 \cup L_2 \cup \dots$ is returned.
 
@@ -116,14 +116,14 @@ WARMR operates in the inductive logic programming setting.  It begins by generat
 
 Aleph \cite{srinivasan2002aleph} uses inverse entailment to generate and evaluate Prolog-style clauses, but does not include built-in surprisingness measures.
 
-\begin{verbatim}
+\begin{algpseudocode}
 Procedure AlephILP(examples, background, settings):
     while not done:
         bottom_clause = derive_bottom_clause(examples, background)
         clause = search_clause_space(bottom_clause, settings)
         evaluate_clause(clause, examples)
         add_best_clause_to_model(clause)
-\end{verbatim}
+\end{algpseudocode}
 
 Aleph constructs, for each positive example, a \emph{bottom clause}--the most specific clause that entails that example given the background logic.  It then searches the space of generalizations of this bottom clause \texttt{(by removing or weakening literals)} according to user settings, evaluates each candidate clause against both positive and negative examples, and adds the highest-scoring clause to its hypothesis model.  This process repeats until a stopping criterion is met, producing an inductively learned set of logical rules.
 


### PR DESCRIPTION
This pull request introduces pseudocode rendering functionality to the frontend, enabling better visualization of pseudocode within LaTeX content. It includes updates to the `latex-parser` to support pseudocode extraction, the addition of a new `PseudocodeRenderer` component, and modifications to existing tutorials to replace `verbatim` blocks with `algpseudocode`. Minor changes also improve code consistency by standardizing string quotes.

### Pseudocode Rendering Enhancements:
* [`frontend/lib/latex-parser.ts`](diffhunk://#diff-400bed5edf86e290ac66af8f385153ed06552325fe1e294923dd1f7e0f64f235L22-R23): Added support for pseudocode content by extending the `LatexContent` type and implementing the `extractPseudocodeContent` function to parse `algpseudocode` blocks. [[1]](diffhunk://#diff-400bed5edf86e290ac66af8f385153ed06552325fe1e294923dd1f7e0f64f235L22-R23) [[2]](diffhunk://#diff-400bed5edf86e290ac66af8f385153ed06552325fe1e294923dd1f7e0f64f235R223-R227) [[3]](diffhunk://#diff-400bed5edf86e290ac66af8f385153ed06552325fe1e294923dd1f7e0f64f235R615-R634)
* [`frontend/components/latex-renderer.tsx`](diffhunk://#diff-2f15587f2d158704cebd1ceefc4981656a52a6fea121e6aa4b6fb16c4a0ec7c9R13): Updated the `LatexRenderer` component to handle pseudocode items using the new `PseudocodeRenderer`. [[1]](diffhunk://#diff-2f15587f2d158704cebd1ceefc4981656a52a6fea121e6aa4b6fb16c4a0ec7c9R13) [[2]](diffhunk://#diff-2f15587f2d158704cebd1ceefc4981656a52a6fea121e6aa4b6fb16c4a0ec7c9R160-R165)

### New Component:
* [`frontend/components/pseudocode-renderer.tsx`](diffhunk://#diff-76a7dba7ef595c2a0cca9c5a6957d7e653ca0536e436eb893e144a2457740716R1-R53): Introduced the `PseudocodeRenderer` component, which renders pseudocode content in a styled card with auto-resizing text areas for improved usability.

### Tutorial Updates:
* [`frontend/tutorials/comparision.tex`](diffhunk://#diff-73dc0bc69b3f5c1ccea0c6f8c891c9e1f626e4a34cbf8e7e9745a92fb5de43abL23-R23): Replaced `verbatim` blocks with `algpseudocode` for algorithms in multiple sections, including Apriori, FP-growth, PrefixSpan, gSpan, WARMR, and Aleph, to leverage the new pseudocode rendering functionality. [[1]](diffhunk://#diff-73dc0bc69b3f5c1ccea0c6f8c891c9e1f626e4a34cbf8e7e9745a92fb5de43abL23-R23) [[2]](diffhunk://#diff-73dc0bc69b3f5c1ccea0c6f8c891c9e1f626e4a34cbf8e7e9745a92fb5de43abL36-R44) [[3]](diffhunk://#diff-73dc0bc69b3f5c1ccea0c6f8c891c9e1f626e4a34cbf8e7e9745a92fb5de43abL56-R71) [[4]](diffhunk://#diff-73dc0bc69b3f5c1ccea0c6f8c891c9e1f626e4a34cbf8e7e9745a92fb5de43abL81-R81) [[5]](diffhunk://#diff-73dc0bc69b3f5c1ccea0c6f8c891c9e1f626e4a34cbf8e7e9745a92fb5de43abL92-R92) [[6]](diffhunk://#diff-73dc0bc69b3f5c1ccea0c6f8c891c9e1f626e4a34cbf8e7e9745a92fb5de43abL102-R102) [[7]](diffhunk://#diff-73dc0bc69b3f5c1ccea0c6f8c891c9e1f626e4a34cbf8e7e9745a92fb5de43abL111-R126)

### Code Consistency:
* [`frontend/lib/latex-parser.ts`](diffhunk://#diff-400bed5edf86e290ac66af8f385153ed06552325fe1e294923dd1f7e0f64f235R250-R257): Standardized string quotes throughout the file for consistency. [[1]](diffhunk://#diff-400bed5edf86e290ac66af8f385153ed06552325fe1e294923dd1f7e0f64f235R250-R257) [[2]](diffhunk://#diff-400bed5edf86e290ac66af8f385153ed06552325fe1e294923dd1f7e0f64f235L270-R284) [[3]](diffhunk://#diff-400bed5edf86e290ac66af8f385153ed06552325fe1e294923dd1f7e0f64f235L287-R294) [[4]](diffhunk://#diff-400bed5edf86e290ac66af8f385153ed06552325fe1e294923dd1f7e0f64f235L309-R323) [[5]](diffhunk://#diff-400bed5edf86e290ac66af8f385153ed06552325fe1e294923dd1f7e0f64f235L326-R333)…